### PR TITLE
check UHAL_VER_* instead of STD_UNORDERED_MAP

### DIFF
--- a/include/IPBusIO/IPBusIO.hh
+++ b/include/IPBusIO/IPBusIO.hh
@@ -3,10 +3,10 @@
 
 #include <uhal/uhal.hpp>
 
-#ifdef STD_UNORDERED_MAP
+#if UHAL_VER_MAJOR >= 2 && UHAL_VER_MINOR >= 8
 #include <unordered_map>
 typedef std::unordered_map<std::string, std::string> uMap;
-#else 
+#else
 #include <boost/unordered_map.hpp>
 typedef boost::unordered_map<std::string, std::string> uMap;
 #endif

--- a/include/IPBusStatus/IPBusStatus.hh
+++ b/include/IPBusStatus/IPBusStatus.hh
@@ -4,14 +4,13 @@
 #include <IPBusIO/IPBusIO.hh>
 #include <BUTool/helpers/StatusDisplay/StatusDisplay.hh>
 
-#ifdef STD_UNORDERED_MAP
+#if UHAL_VER_MAJOR >= 2 && UHAL_VER_MINOR >= 8
 #include <unordered_map>
 typedef std::unordered_map<std::string, std::string> uMap;
-#else 
+#else
 #include <boost/unordered_map.hpp>
 typedef boost::unordered_map<std::string, std::string> uMap;
 #endif
-
 class IPBusStatus: public IPBusIO, public BUTool::StatusDisplay {
 public:
   IPBusStatus(uhal::HwInterface * const * _hw){SetHWInterface(_hw);};


### PR DESCRIPTION
check for `UHAL_VER`s `MAJOR` and `MINOR` to be defined instead of `STD_UNORDERED_MAP` - keep default 2.7