### PR TITLE
Catch and throw uHAL exceptions during device creation 

### DIFF
--- a/src/IPBusIO/IPBusConnection.cpp
+++ b/src/IPBusIO/IPBusConnection.cpp
@@ -130,7 +130,7 @@ void IPBusConnection::Connect(std::vector<std::string> const & arg){
 										  uri,
 										  addrTableFull));
     } catch( uhal::exception::exception& e) {
-      e.append("Module::Connect() creating hardware device");
+      e.append("Module::Connect() creating hardware device\n");
       e.append("Error creating uHAL hardware device\n");
       throw;
     }
@@ -159,7 +159,7 @@ void IPBusConnection::Connect(std::vector<std::string> const & arg){
     try {
       hw = std::make_shared<uhal::HwInterface>( manager.getDevice ( connectionFileEntry.c_str() ));
     }  catch (uhal::exception::exception& e) {
-      e.append("Module::Connect() creating hardware device");
+      e.append("Module::Connect() creating hardware device\n");
       e.append(("Error while creating uHAL hardware device " + connectionFileEntry + " from connection file " + connectionFile + "\n").c_str());
       throw;
     }
@@ -193,7 +193,7 @@ void IPBusConnection::Connect(std::vector<std::string> const & arg){
     try {
       hw = std::make_shared<uhal::HwInterface>( uhal::ConnectionManager::getDevice(IPBusDeviceTypeName.c_str(), uri, addrTableFull + "/" + IPBusDeviceTypeName + ".xml"));
     } catch( uhal::exception::exception& e) {
-      e.append("Module::Connect() creating hardware device");
+      e.append("Module::Connect() creating hardware device\n");
       e.append("Error creating uHAL hardware device\n");
       throw;
     }

--- a/src/IPBusIO/IPBusConnection.cpp
+++ b/src/IPBusIO/IPBusConnection.cpp
@@ -131,7 +131,8 @@ void IPBusConnection::Connect(std::vector<std::string> const & arg){
 										  addrTableFull));
     } catch( uhal::exception::exception& e) {
       e.append("Module::Connect() creating hardware device");
-      printf("Error creating uHAL hardware device\n");
+      e.append("Error creating uHAL hardware device\n");
+      throw;
     }
 
   } else if( boost::regex_match( connectionFile.c_str(), reMatch, reXMLFile) ) {
@@ -159,7 +160,8 @@ void IPBusConnection::Connect(std::vector<std::string> const & arg){
       hw = std::make_shared<uhal::HwInterface>( manager.getDevice ( connectionFileEntry.c_str() ));
     }  catch (uhal::exception::exception& e) {
       e.append("Module::Connect() creating hardware device");
-      printf("Error while creating uHAL hardware device %s from connection file %s\n", connectionFileEntry.c_str(), connectionFile.c_str());
+      e.append(("Error while creating uHAL hardware device " + connectionFileEntry + " from connection file " + connectionFile + "\n").c_str());
+      throw;
     }
 
   } else { // hostname less '_t2' and '_t1'   
@@ -192,7 +194,8 @@ void IPBusConnection::Connect(std::vector<std::string> const & arg){
       hw = std::make_shared<uhal::HwInterface>( uhal::ConnectionManager::getDevice(IPBusDeviceTypeName.c_str(), uri, addrTableFull + "/" + IPBusDeviceTypeName + ".xml"));
     } catch( uhal::exception::exception& e) {
       e.append("Module::Connect() creating hardware device");
-      printf("Error creating uHAL hardware device\n");
+      e.append("Error creating uHAL hardware device\n");
+      throw;
     }
 
   }


### PR DESCRIPTION
If uHAL exceptions are caught when `add_device` BUTool command is invoked, this PR updates the code such that `add_device` will throw an exception instead of finishing adding that device, causing a segfault later on. 

**Test on SM209:**
```
>add_device APOLLOSM invalid.xml 
Using .xml connection file...
Warning: Input is a connection file but no device entry specified, using default entry name: test.0
Exception: Connection map contains no entries
Module::Connect() creating hardware device
Error while creating uHAL hardware device test.0 from connection file invalid.xml

 add_device          :   Add a new device and make it active.
                           Usage:
                           add_device <type> <args>

# No devices are added! 
>list
>
```